### PR TITLE
Update plugin to work with new worker API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,13 @@
+# Editor Stuff
+*~
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+.vscode/*
+.idea/*
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/receptor_http/worker.py
+++ b/receptor_http/worker.py
@@ -17,7 +17,7 @@ async def get_url(method, url, **extra_data):
     async with aiohttp.ClientSession() as session:
         async with session.request(method, url, **extra_data) as response:
             response_text = dict(status=response.status,
-                                    body=await response.text())
+                                 body=await response.text())
     return response_text
 
 


### PR DESCRIPTION
This updates the plugin to reflect the changes in project-receptor/receptor#128. Instead of using an asyncio queue, the plugin runs in its own thread and gets a regular Python thread-safe queue to put responses on.