### PR TITLE
Mark receptor-callable worker method as exportable

### DIFF
--- a/receptor_http/worker.py
+++ b/receptor_http/worker.py
@@ -13,6 +13,11 @@ def configure_logger():
         logger.addHandler(handler)
 
 
+def receptor_export(func):
+    setattr(func, "receptor_export", True)
+    return func
+
+
 async def get_url(method, url, **extra_data):
     async with aiohttp.ClientSession() as session:
         async with session.request(method, url, **extra_data) as response:
@@ -21,6 +26,7 @@ async def get_url(method, url, **extra_data):
     return response_text
 
 
+@receptor_export
 def execute(message, config, result_queue):
     configure_logger()
 


### PR DESCRIPTION
Flag the receptor-callable method so receptor's work.py knows which one it's supposed to be allowed to call.  See https://github.com/project-receptor/receptor/pull/128/commits/f109f9e92f5562c95b7e435f77f1bb78edaad2bb