### PR TITLE
Exporting receptor_http:execute

### DIFF
--- a/receptor_http/worker.py
+++ b/receptor_http/worker.py
@@ -5,7 +5,10 @@ import aiohttp
 
 logger = logging.getLogger(__name__)
 
-
+def receptor_export(func):
+    setattr(func, "receptor_export", True)
+    return func
+    
 def configure_logger():
     receptor_logger = logging.getLogger('receptor')
     logger.setLevel(receptor_logger.level)
@@ -21,6 +24,7 @@ async def get_url(method, url, **extra_data):
     return response_text
 
 
+@receptor_export
 def execute(message, config, result_queue):
     configure_logger()
 


### PR DESCRIPTION
`receptor_http:execute` call returns `Not allowed to call execute from receptor_http because it is not marked for export`.

This seems to be fixing it